### PR TITLE
Fix most of the compilation warnings

### DIFF
--- a/src/base64.h
+++ b/src/base64.h
@@ -11,7 +11,7 @@ https://en.wikipedia.org/wiki/Base64
 
 static bool isBase64Char(char c);
 static char base64decode_byte(char c);
-static bool base64decode(char *decoded, char *source, size_t len);
+static bool base64decode(char *decoded, const char *source, size_t len);
 
 // returns true is the char given as parameter is a valid base64 char and false
 // otherwise
@@ -41,7 +41,7 @@ static char base64decode_byte(char c) {
 }
 
 // decode base64 data
-static bool base64decode(char *decoded, char *source, size_t len) {
+static bool base64decode(char *decoded, const char *source, size_t len) {
     for (size_t i = 0; i < len / 4; i++) {
         uint32_t data = 0;
         for (int j = 0; j < 4; j++) {

--- a/src/main.c
+++ b/src/main.c
@@ -68,7 +68,7 @@ void handle_apdu(volatile unsigned int *flags, volatile unsigned int *tx) {
             switch (G_io_apdu_buffer[OFFSET_INS]) {
                 case INS_GET_APP_VERSION:
                     *tx = strlen(APPVERSION);
-                    os_memcpy(G_io_apdu_buffer, APPVERSION, *tx);
+                    memcpy(G_io_apdu_buffer, APPVERSION, *tx);
                     THROW(MSG_OK);
                     break;
 

--- a/src/parse_tx.c
+++ b/src/parse_tx.c
@@ -12,8 +12,7 @@
 #include "globals.h"
 #endif
 
-static void extract_esdt_value(const uint8_t *encoded_data_field,
-                               const uint8_t encoded_data_length);
+static void extract_esdt_value(const char *encoded_data_field, const uint8_t encoded_data_length);
 static void set_network(const char *chain_id);
 static void set_message_in_amount(const char *message);
 
@@ -256,8 +255,7 @@ uint16_t verify_data(bool *valid) {
     return MSG_OK;
 }
 
-static void extract_esdt_value(const uint8_t *encoded_data_field,
-                               const uint8_t encoded_data_length) {
+static void extract_esdt_value(const char *encoded_data_field, const uint8_t encoded_data_length) {
     if (encoded_data_length == 0) {
         return;
     }
@@ -267,7 +265,7 @@ static void extract_esdt_value(const uint8_t *encoded_data_field,
     }
 
     int esdt_value_start_position = INVALID_INDEX;
-    for (int idx = ESDT_TRANSFER_PREFIX_LENGTH; idx < strlen(data_field); idx++) {
+    for (size_t idx = ESDT_TRANSFER_PREFIX_LENGTH; idx < strlen(data_field); idx++) {
         if (data_field[idx] == SC_ARGS_SEPARATOR) {
             esdt_value_start_position = idx + 1;
             break;
@@ -278,7 +276,7 @@ static void extract_esdt_value(const uint8_t *encoded_data_field,
     }
 
     int esdt_value_end_position = INVALID_INDEX;
-    for (int idx = esdt_value_start_position; idx < strlen(data_field); idx++) {
+    for (size_t idx = esdt_value_start_position; idx < strlen(data_field); idx++) {
         if (data_field[idx] == SC_ARGS_SEPARATOR || data_field[idx] == BASE_64_INVALID_CHAR) {
             esdt_value_end_position = idx - 1;
             break;

--- a/src/sign_msg.c
+++ b/src/sign_msg.c
@@ -150,11 +150,10 @@ void handle_sign_msg(uint8_t p1,
 
     // finalize hash, compute it and store it in `msg_context.strhash` for display
     cx_hash((cx_hash_t *) &sha3_context, CX_LAST, data_buffer, 0, msg_context.hash, HASH_LEN);
-    snprintf(msg_context.strhash,
-             sizeof(msg_context.strhash),
-             "%.*H",
-             sizeof(msg_context.hash),
-             msg_context.hash);
+    convert_to_hex_str(msg_context.strhash,
+                       sizeof(msg_context.strhash),
+                       msg_context.hash,
+                       sizeof(msg_context.hash));
 
     // sign the hash
     if (!sign_message()) {

--- a/src/utils.c
+++ b/src/utils.c
@@ -4,7 +4,7 @@
 
 // read_uint32_be reads 4 bytes from the buffer and returns an uint32_t with big
 // endian encoding
-uint32_t read_uint32_be(uint8_t *buffer) {
+uint32_t read_uint32_be(uint8_t* buffer) {
     return (buffer[0] << 24) | (buffer[1] << 16) | (buffer[2] << 8) | (buffer[3]);
 }
 
@@ -21,7 +21,7 @@ void send_response(uint8_t tx, bool approve) {
 }
 
 // TODO: refactor this function
-void uint32_t_to_char_array(uint32_t const input, char *output) {
+void uint32_t_to_char_array(uint32_t const input, char* output) {
     uint32_t const base = 10;
     uint32_t index;
     uint8_t pos = 0;
@@ -32,4 +32,22 @@ void uint32_t_to_char_array(uint32_t const input, char *output) {
         output[pos++] = '0' + ((input / index) % base);
     }
     output[pos] = '\0';
+}
+
+void convert_to_hex_str(char* destination,
+                        size_t destination_size,
+                        const uint8_t* source,
+                        size_t source_size) {
+    static char hex[] = "0123456789ABCDEF";
+    int i = 0;
+
+    if (source_size * 2 > destination_size) {
+        source_size = destination_size / 2;
+    }
+
+    for (i = 0; i < (int) source_size; i++) {
+        destination[(i * 2)] = hex[((source[i] & 0xF0) >> 4)];
+        destination[(i * 2) + 1] = hex[((source[i] & 0x0F) >> 0)];
+    }
+    destination[i * 2] = '\0';
 }

--- a/src/utils.h
+++ b/src/utils.h
@@ -5,10 +5,15 @@
 #include <stddef.h>
 #include <stdint.h>
 
-uint32_t read_uint32_be(uint8_t *buffer);
+uint32_t read_uint32_be(uint8_t* buffer);
 
 void send_response(uint8_t tx, bool approve);
 
-void uint32_t_to_char_array(uint32_t const input, char *output);
+void uint32_t_to_char_array(uint32_t const input, char* output);
+
+void convert_to_hex_str(char* destination,
+                        size_t destination_size,
+                        const uint8_t* source,
+                        size_t source_size);
 
 #endif

--- a/src/view_app_version.c
+++ b/src/view_app_version.c
@@ -97,6 +97,7 @@ static const bagl_element_t app_version_ui[] = {
     },
     {
         {BAGL_ICON, 0x00, 117, 13, 7, 7, 0, 0, 0, 0xFFFFFF, 0x000000, 0, BAGL_GLYPH_ICON_UP},
+        NULL,
     },
 #endif
 };


### PR DESCRIPTION
One warning left as I was unsure of the intended behavior :
```
src/sign_msg.c:155:18: warning: invalid conversion specifier 'H' [-Wformat-invalid-specifier]
             "%.*H",
              ~~~^
src/sign_msg.c:157:14: warning: data argument not used by format string [-Wformat-extra-args]
             msg_context.hash);
             ^
```